### PR TITLE
update new import path for golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 .PHONY: bootstrap
 bootstrap:
 	@echo "+ $@"
-	@go get -u -v github.com/golang/lint/golint
+	@go get -u -v golang.org/x/lint/golint
 	@go get -u -v github.com/golang/dep/cmd/dep
 	@dep ensure
 


### PR DESCRIPTION
The import path within the `MakeFile` for **golint** should now point to `golang.org`. (see [this](https://github.com/golang/lint/issues/415#issuecomment-511234597))